### PR TITLE
Add optional Substack link, scheduled date, and updated-date to blog entries

### DIFF
--- a/assets/site.css
+++ b/assets/site.css
@@ -12,6 +12,9 @@
   --tag-bg: #e8e8e0;
   --tag-fg: #555;
   --nav-bg: rgba(255, 255, 248, 0.95);
+  --substack-bg: #fff0e6;
+  --substack-fg: #b84e00;
+  --updated-fg: #1a6b3e;
 }
 
 /* System preference dark mode */
@@ -26,6 +29,9 @@
     --tag-bg: #2a2a2a;
     --tag-fg: #bbb;
     --nav-bg: rgba(21, 21, 21, 0.95);
+    --substack-bg: #2a1508;
+    --substack-fg: #e07840;
+    --updated-fg: #4fa872;
   }
 }
 
@@ -40,6 +46,9 @@
   --tag-bg: #2a2a2a;
   --tag-fg: #bbb;
   --nav-bg: rgba(21, 21, 21, 0.95);
+  --substack-bg: #2a1508;
+  --substack-fg: #e07840;
+  --updated-fg: #4fa872;
 }
 
 /* Manual light mode override */
@@ -53,6 +62,9 @@
   --tag-bg: #e8e8e0;
   --tag-fg: #555;
   --nav-bg: rgba(255, 255, 248, 0.95);
+  --substack-bg: #fff0e6;
+  --substack-fg: #b84e00;
+  --updated-fg: #1a6b3e;
 }
 
 /* Apply variables — override Tufte's hardcoded colors */
@@ -253,6 +265,49 @@ article > ul {
   font-size: 1.1rem;
   color: var(--tag-fg);
   margin-top: 0.2rem;
+}
+
+/* Substack link badge — links to the published Substack version */
+.post-item .substack-link {
+  display: inline-block;
+  font-family: et-book-roman-old-style, et-book, Georgia, serif;
+  font-size: 0.85rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 1rem;
+  background: var(--substack-bg);
+  color: var(--substack-fg);
+  margin-right: 0.4rem;
+  vertical-align: middle;
+  text-decoration: none;
+}
+
+.post-item .substack-link:visited {
+  color: var(--substack-fg);
+}
+
+.post-item .substack-link:hover {
+  text-decoration: underline;
+}
+
+/* Substack scheduled date — shown when not yet published */
+.post-item .substack-date {
+  display: inline-block;
+  font-family: et-book-roman-old-style, et-book, Georgia, serif;
+  font-size: 0.85rem;
+  padding: 0.1rem 0.5rem;
+  border-radius: 1rem;
+  background: var(--substack-bg);
+  color: var(--substack-fg);
+  margin-right: 0.4rem;
+  vertical-align: middle;
+}
+
+/* Updated date label — visually similar to <time> but in a distinct color */
+.post-item .post-updated {
+  font-family: et-book-roman-old-style, et-book, Georgia, serif;
+  font-size: 1.1rem;
+  color: var(--updated-fg);
+  margin-right: 0.5rem;
 }
 
 @media (max-width: 760px) {

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
 
     <li class="post-item" data-tags="philosophy">
       <time>2026-03-23</time>
+      <span class="post-updated">Updated 2026-03-24</span>
       <span class="tag">philosophy</span>
       <a href="notes/why-now-observer-coherence.html">Why Now? Observer-Coherence and the Measure Over Minds</a>
       <span class="description">Our place in the multiverse: youngness bias as an answer to the paradoxes of self-indication. By Claude Opus 4.6.</span>
@@ -41,6 +42,7 @@
       <time>2026-03-23</time>
       <span class="tag">philosophy</span>
       <span class="tag">dev</span>
+      <a class="substack-link" href="https://lukstafi.substack.com/p/operations-of-discovery">Substack ↗</a>
       <a href="notes/operations-of-discovery.html">The Operations of Discovery</a>
       <span class="description">On poetry, software engineering, and the human. By Claude Opus 4.6.</span>
     </li>
@@ -48,6 +50,7 @@
     <li class="post-item" data-tags="dev">
       <time>2026-03-20</time>
       <span class="tag">dev</span>
+      <span class="substack-date">Substack: Mar 28</span>
       <a href="notes/the-furnace-building-personal-ai-infrastructure.html">The Furnace: Building Personal AI Infrastructure on the Eve of Singularity</a>
       <span class="description">The genesis and exposition of my Ludics project, autonomous task manager, and agent-duo subproject, orchestrating across Claude Code and Codex. Written by Claude Opus 4.6 in my voice.</span>
     </li>


### PR DESCRIPTION
## Summary

- Added CSS variables (`--substack-bg`, `--substack-fg`, `--updated-fg`) to all four theme blocks (light default, dark system preference, manual dark, manual light) in `assets/site.css`
- Added `.substack-link` pill badge style — links to the published Substack version of an article (warm orange/brown palette, consistent with Tufte theme)
- Added `.substack-date` pill badge style — shows a scheduled Substack release date for articles not yet published (same palette as `.substack-link`)
- Added `.post-updated` inline label style — distinct green color to differentiate from the grey `<time>` date
- Demonstrated all three features on the first three entries in `index.html`

## How to use

Add any combination of these optional elements inside a `<li class="post-item">`:

\`\`\`html
<!-- Published Substack link -->
<a class="substack-link" href="https://lukstafi.substack.com/p/slug">Substack ↗</a>

<!-- Scheduled Substack date (not yet published) -->
<span class="substack-date">Substack: Mar 28</span>

<!-- Updated date -->
<span class="post-updated">Updated 2026-03-24</span>
\`\`\`

Entries without these elements render unchanged.

## Test plan

- [x] Verified all three badge types render in `index.html` (first three entries)
- [x] CSS variables cover both light and dark mode (system preference + manual toggle)
- [x] Entries without optional elements are visually unchanged
- [x] No build step required — static HTML/CSS site

🤖 Generated with [Claude Code](https://claude.com/claude-code)